### PR TITLE
feat(0.1.5): ZFS 2.2.7 and Kernel 6.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729712798,
-        "narHash": "sha256-a+Aakkb+amHw4biOZ0iMo8xYl37uUL48YEXIC5PYJ/8=",
+        "lastModified": 1734343412,
+        "narHash": "sha256-b7G8oFp0Nj01BYUJ6ENC9Qf/HsYAIZvN9k/p0Kg/PFU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "09a776702b004fdf9c41a024e1299d575ee18a7d",
+        "rev": "a08bfe06b39e94eec98dd089a2c1b18af01fef19",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1729742320,
-        "narHash": "sha256-u3Of8xRkN//me8PU+RucKA59/6RNy4B2jcGAF36P4jI=",
+        "lastModified": 1734352517,
+        "narHash": "sha256-mfv+J/vO4nqmIOlq8Y1rRW8hVsGH3M+I2ESMjhuebDs=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda",
+        "rev": "b12e314726a4226298fe82776b4baeaa7bcf3dcd",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729716953,
-        "narHash": "sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX+uq6A=",
+        "lastModified": 1734344598,
+        "narHash": "sha256-wNX3hsScqDdqKWOO87wETUEi7a/QlPVgpC/Lh5rFOuA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7",
+        "rev": "83ecd50915a09dca928971139d3a102377a8d242",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1729068498,
-        "narHash": "sha256-C2sGRJl1EmBq0nO98TNd4cbUy20ABSgnHWXLIJQWRFA=",
+        "lastModified": 1734200366,
+        "narHash": "sha256-0NursoP4BUdnc+wy+Mq3icHkXu/RgP1Sjo0MJxV2+Dw=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "e337457502571b23e449bf42153d7faa10c0a562",
+        "rev": "c6323585fa0035d780e3d8906eb1b24b65d19a48",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729742320,
-        "narHash": "sha256-u3Of8xRkN//me8PU+RucKA59/6RNy4B2jcGAF36P4jI=",
+        "lastModified": 1734352517,
+        "narHash": "sha256-mfv+J/vO4nqmIOlq8Y1rRW8hVsGH3M+I2ESMjhuebDs=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda",
+        "rev": "b12e314726a4226298fe82776b4baeaa7bcf3dcd",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {
@@ -152,29 +152,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1729357638,
-        "narHash": "sha256-66RHecx+zohbZwJVEPF7uuwHeqf8rykZTMCTqIrOew4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bb8c2cf7ea0dd2e18a52746b2c3a5b0c73b93c22",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {
@@ -187,10 +171,10 @@
     "private-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1726686385,
-        "narHash": "sha256-KLz9lK84nmpoyP+O/qtGY1tOgS8xRsjTRGHtYlHlHVM=",
+        "lastModified": 1734547668,
+        "narHash": "sha256-3CHAU6c0dwQP+fS6vhdWQCVvFnl8ea2NBBQSEIzhfNM=",
         "ref": "main",
-        "rev": "977628c9ddf2fce0b890b5322f21c0f93a203cbd",
+        "rev": "d3e9a013b9ab0a2089f0586d3757f7868a736e24",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/psiri/nixos-secrets.git"
@@ -220,15 +204,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1729775275,
-        "narHash": "sha256-J2vtHq9sw1wWm0aTMXpEEAzsVCUMZDTEe5kiBYccpLE=",
+        "lastModified": 1734546875,
+        "narHash": "sha256-6OvJbqQ6qPpNw3CA+W8Myo5aaLhIJY/nNFDk3zMXLfM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "78a0e634fc8981d6b564f08b6715c69a755c4c7d",
+        "rev": "ed091321f4dd88afc28b5b4456e0a15bd8374b4d",
         "type": "github"
       },
       "original": {

--- a/home/chrome/default.nix
+++ b/home/chrome/default.nix
@@ -43,7 +43,7 @@
       "eimadpbcbfnmbkopoojfekhnkhdbieeh" # Dark Reader
       "ponfpcnoihfmfllpaingbgckeeldkhle" # Enhancer for YouTube
       #"callobklhcbilhphinckomhgkigmfocg" # Google Endpoint Verification
-      "pkehgijcmpdhfbdbbnkijodmdjhbjlgp" # Privacy Badger
+      #"pkehgijcmpdhfbdbbnkijodmdjhbjlgp" # Privacy Badger
     ];
     extraOpts = {
       "BrowserSignin" = 1;

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -96,6 +96,7 @@ input {
     repeat_rate = 50
     sensitivity = 0
     # fixed touchpad, needed indentation to work correctly :)
+    scroll_factor = 7.0
     touchpad {
         natural_scroll = yes
         disable_while_typing = true
@@ -114,11 +115,11 @@ general {
 
 decoration {
     rounding = 10
-    drop_shadow = 1
-    shadow_range = 30
-    shadow_render_power = 3
-    col.shadow = $ca
-    col.shadow_inactive= $c0
+    #drop_shadow = 1
+    #shadow_range = 30
+    #shadow_render_power = 3
+    #col.shadow = $ca
+    #col.shadow_inactive= $c0
     active_opacity = 1
     inactive_opacity = .90
     dim_inactive = true
@@ -156,7 +157,7 @@ animations {
 ############################################ Layouts ###################################################
 
 dwindle {
-    no_gaps_when_only = false
+    #no_gaps_when_only = false
     pseudotile = true # master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
     preserve_split = true # you probably want this
     smart_resizing = true

--- a/home/obs-studio/default.nix
+++ b/home/obs-studio/default.nix
@@ -15,9 +15,9 @@
     };
     home.file.".config/hypr/per-app/obs-studio.conf" = {
       text = ''
-        # windowrulev2 = opacity 0.8 0.8, class:^(obs-studio)$
-        # windowrulev2 = size 700 300, class:^(obs-studio)$
         # windowrulev2 = tile, class:^(obs-studio)$
+        windowrulev2 = opacity 1.0 1.0, class:^(com.obsproject.Studio)$   # Disables opacity of OBS windows
+        windowrulev2 = nodim, class:^(com.obsproject.Studio)$             # Disables dimming of OBS windows
         bind = $mainMod, O, exec, obs
       '';
     };

--- a/hosts/fw16-nix/hardware-configuration.nix
+++ b/hosts/fw16-nix/hardware-configuration.nix
@@ -67,7 +67,7 @@
     #"pci-stub.ids=1002:7480,1002:ab30"
     "mem_sleep_default=deep" # Fix for AMD-related power-draw while syspended/sleeping
   ];
-  boot.kernelPackages = pkgs.linuxPackages_6_10; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
+  boot.kernelPackages = pkgs.linuxPackages_6_12; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
   boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];# Used for OBS virtual cameras as Zoom screen sharing workaround
 
   swapDevices = [ ];

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -6,6 +6,9 @@
 
       # Primary external monior (centered)
       monitor=DP-3,3840x2160@30.00,6400x0,1
+      # Primary monitor when run through TB3 dock
+      monitor=DP-7,3840x2160@60.00,6400x0,1
+      monitor=DP-8,3840x2160@60.00,6400x0,1
 
       # Secondary external monitor. Place it to the right of primary & rotate 90 deg
       #monitor=DP-2,3840x2160@60.00, 2560x0, 1, transform, 1
@@ -13,7 +16,11 @@
       monitor=DP-2,3840x2160@60.00,2560x0, 1
 
       # Tertiary external monitor. Place it using auto-layout
-      monitor=DP-4,3840x2160@60.00,auto,1
+      monitor=DP-4,3840x2160@60.00, auto, 1
+
+
+      # Any other random monitor default settings
+      monitor = , 3840x2160@60.00, auto, 1
 
       # trigger when the Lid Switch is turning on (lid closed)
       bindl = , switch:on:Lid Switch,exec,hyprctl keyword monitor "eDP-1, disable"

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -20,7 +20,7 @@
 
 
       # Any other random monitor default settings
-      monitor = , 3840x2160@60.00, auto, 1
+      monitor = , 3840x2160@30.00, auto, 1
 
       # trigger when the Lid Switch is turning on (lid closed)
       bindl = , switch:on:Lid Switch,exec,hyprctl keyword monitor "eDP-1, disable"

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -155,12 +155,13 @@
     packages = with pkgs; [
       fira-code
       fira-code-symbols
-      fira-code-nerdfont
       hack-font
       material-design-icons
       material-symbols
       meslo-lgs-nf # powerlevel10k recommended font
-      nerdfonts
+      nerd-fonts.hack
+      nerd-fonts.fira-code
+      nerd-fonts.inconsolata
       #(nerdfonts.override {fonts = ["FiraCode" "JetBrainsMono"];})
     ];
   };
@@ -204,7 +205,7 @@
         slack
         slurp             # used in conjunction with grim for screenshotting while flameshot is broken
         spotify
-        # teams-for-linux # UNOFFICIAL MS Teams client, dropping this in favor of browser-based client
+        teams-for-linux # UNOFFICIAL MS Teams client, dropping this in favor of browser-based client
         # teamviewer
         vlc               # media player
         wl-clipboard      # tool for accessing Wayland clipboards
@@ -328,6 +329,8 @@
 
 
   services.teamviewer.enable = false;
+
+  services.hardware.bolt.enable = true; # Thunderbolt support:  https://nixos.wiki/wiki/Thunderbolt
 
 
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion


### PR DESCRIPTION
- Finally upgrade kernel to 6.12 now that ZFS (2.2.7) supports it
- Removed Hyprland config options that are no longer present
- Update nerdfonts to new package name
- Enable thunderbolt 3/4 support
- Add teams-for-linux