### PR TITLE
fix(0.1.7): Fix Okta MFA issues with Chromium and Chromium-based Browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following table breaks down the respective hardware and software / feature c
 | File Manager         | Thunar                                                     | standard           |    system    |
 | IDE                  | Codium (VS Code OSS)                                       | standard           |     user     |
 | Idle Daemon          | hypridle                                                   | standard           |     user     |
+| Image Editor         | gimp                                                       | standard           |     user     |
 | Media Player         | spotify, vlc                                               | standard           |     user     |
 | Network Tools        | curl, dig, dnsutils, iputils, mtr, netcat, nmap, ntp, openssl, wget, wireshark  | standard, server   |  system    |
 | Notes                | joplin-desktop                                             | standard           |     user     |
@@ -39,7 +40,7 @@ The following table breaks down the respective hardware and software / feature c
 | Terminal             | Kitty                                                      | standard           |     user     |
 | Text Editor          | nano                                                       | standard, server   |    system    |
 | Virtualization       | KVM, QEMU, vert-manager                                    | standard, server   |    system    |
-| VPN       | globalprotect-openconnect, openconnect, networkmanager-openconnect    | standard           |    system    |
+| VPN       | globalprotect-openconnect, openconnect, networkmanager-openconnect, tailscale    | standard           |    system    |
 | Window Manager       | Hyprland                                                   | standard           |    system    |
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736437680,
-        "narHash": "sha256-9Sy17XguKdEU9M5peTrkWSlI/O5IAqjHzdzxbXnc30g=",
+        "lastModified": 1737038063,
+        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4d5d07d37ff773338e40a92088f45f4f88e509c8",
+        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1736441705,
-        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
+        "lastModified": 1737590910,
+        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
+        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736421950,
-        "narHash": "sha256-RyrX0WFXxFrYvzHNLTIyuk3NcNl3UBykuYru/P0zW5E=",
+        "lastModified": 1737704314,
+        "narHash": "sha256-zta8jvOQ2wRCZmiwFEnS5iCulWAh8e+fLUlQxrgOBjM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4aebb947a301b8da8654a804979a738c5c5da50",
+        "rev": "a0428685572b134f6594e7d7f5db5e1febbab2d7",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1734945620,
-        "narHash": "sha256-olIfsfJK4/GFmPH8mXMmBDAkzVQ1TWJmeGT3wBGfQPY=",
+        "lastModified": 1736688610,
+        "narHash": "sha256-1Zl9xahw399UiZSJ9Vxs1W4WRFjO1SsNdVZQD4nghz0=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "d000479f4f41390ff7cf9204979660ad5dd16176",
+        "rev": "c64bed13b562fc3bb454b48773d4155023ac31b7",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736441705,
-        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
+        "lastModified": 1737590910,
+        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
+        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1737632463,
+        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "lastModified": 1737632463,
+        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736203741,
-        "narHash": "sha256-eSjkBwBdQk+TZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4=",
+        "lastModified": 1737411508,
+        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c9c88f08e3ee495e888b8d7c8624a0b2519cb773",
+        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737038063,
-        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
+        "lastModified": 1738765162,
+        "narHash": "sha256-3Z40qHaFScWUCVQrGc4Y+RdoPsh1R/wIh+AN4cTXP0I=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
+        "rev": "ff3568858c54bd306e9e1f2886f0f781df307dff",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1737590910,
-        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
+        "lastModified": 1738816619,
+        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
+        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737704314,
-        "narHash": "sha256-zta8jvOQ2wRCZmiwFEnS5iCulWAh8e+fLUlQxrgOBjM=",
+        "lastModified": 1739287084,
+        "narHash": "sha256-CtRNJsqsXIArJV+AKWZVBMO8PD1FQB69br+WMtTJEgI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0428685572b134f6594e7d7f5db5e1febbab2d7",
+        "rev": "8f351726c5841d86854e7fa6003ea472352f5208",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1736688610,
-        "narHash": "sha256-1Zl9xahw399UiZSJ9Vxs1W4WRFjO1SsNdVZQD4nghz0=",
+        "lastModified": 1737831083,
+        "narHash": "sha256-LJggUHbpyeDvNagTUrdhe/pRVp4pnS6wVKALS782gRI=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "c64bed13b562fc3bb454b48773d4155023ac31b7",
+        "rev": "4b3e914cdf97a5b536a889e939fb2fd2b043a170",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737590910,
-        "narHash": "sha256-qM/y6Dtpu9Wmf5HqeZajQdn+cS0aljdYQQQnrvx+LJE=",
+        "lastModified": 1738816619,
+        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9368027715d8dde4b84c79c374948b5306fdd2db",
+        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
         "type": "github"
       },
       "original": {
@@ -171,10 +171,10 @@
     "private-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1735321717,
-        "narHash": "sha256-qo7f+gbRnG2fomt195zB4RtRvjmQDMVr+N3O1ISQaWk=",
+        "lastModified": 1739291321,
+        "narHash": "sha256-CQk82+4s2Qg+CrZ8/QpEmgF5dqJf/KxMzT9Lljjv+HI=",
         "ref": "main",
-        "rev": "0d0e2be18c76d08fcb3910c19197ac3e9237157b",
+        "rev": "7c8b91aa738ecc51f883539281d3b2e41c4fc388",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/psiri/nixos-secrets.git"
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737411508,
-        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
+        "lastModified": 1739262228,
+        "narHash": "sha256-7JAGezJ0Dn5qIyA2+T4Dt/xQgAbhCglh6lzCekTVMeU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
+        "rev": "07af005bb7d60c7f118d9d9f5530485da5d1e975",
         "type": "github"
       },
       "original": {

--- a/home/chrome/default.nix
+++ b/home/chrome/default.nix
@@ -149,7 +149,7 @@
         "hosted_app_data"
       ];
       "CommandLineFlagSecurityWarningsEnabled" = true; # true = show securitry warnings when potentially dangerous command-line flags are used
-      "DefaultBwoeserSettingEnabled" = false;          # true = Enable default browser check on startup
+      "DefaultBrowserSettingEnabled" = false;          # true = Enable default browser check on startup
       #"DefaultDownloadDirectory"     = "$HOME/Downloads" # unset = use platform-specific defaults
       "DnsOverHttpsMode" = "automatic";  # off = disable DoH, automatic = Enable with insecure fallback, secure = force DoH only
       #DnsOverHttpsTemplates = 

--- a/home/chrome/default.nix
+++ b/home/chrome/default.nix
@@ -103,7 +103,7 @@
       #                 KERBEROS                #
       ###########################################
       "KerberosAccounts" = [];
-      "KerberosAddAccountsAllowed" = false;  # true = Allow users to add Kerberos accoutns
+      "KerberosAddAccountsAllowed" = false;  # true = Allow users to add Kerberos accounts
       "KerberosEnabled" = false;             # true = Enable Kerberos, false = disable
       "KerberosRememberPasswordEnabled" = false; # true = Allow users to remember Kerberos passwords
       ###########################################

--- a/home/chrome/default.nix
+++ b/home/chrome/default.nix
@@ -131,6 +131,10 @@
       "AudioOutputAllowed" = true;      # true = enable audio output
       "AudioSandboxEnabled" = null;     # true = Always sandbox the process, false = never, not set = use default
       "BlockThirdPartyCookies" = true;  # true = Block 3rd party cookies
+      "CookiesAllowedForUrls" = [       # NOTE: With BlockThirdPartyCookies = true, you must explicitly authorize cookies
+        "[*.]oktacdn.com"               #       for certain sites (like Otka), or functionalities like MFA / TOIP / FIDO auth will break.
+        "[*.]okta.com"                  # These two entries fix MFA issues with Otka
+      ];
       "BrowserAddPersonEnabled" = true; # true = Allows adding a person to the user manager
       "BrowserLabsEnabled" = false;     # true = Users can access browser experimental features
       "BrowserSignIn" = 1;              # 0 = Disable, 1=Enable, 2=Force sign-in

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -7,13 +7,15 @@
       # Primary external monior (centered)
       monitor=DP-3,3840x2160@30.00,6400x0,1
       # Primary monitor when run through TB3 dock
-      monitor=DP-7,3840x2160@60.00,6400x0,1
       monitor=DP-8,3840x2160@60.00,6400x0,1
+
+      # Secondary monitor (LEFT) when run through TB3 dock
+      monitor=DP-7,3840x2160@60.00,2560x0,1
 
       # Secondary external monitor. Place it to the right of primary & rotate 90 deg
       #monitor=DP-2,3840x2160@60.00, 2560x0, 1, transform, 1
       # Secondary external monitor. Place it to the right of primary (without rotation)
-      monitor=DP-2,3840x2160@60.00,2560x0, 1
+      monitor=DP-2,3840x2160@60.00,10240x0, 1
 
       # Tertiary external monitor. Place it using auto-layout
       monitor=DP-4,3840x2160@60.00, auto, 1

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -7,15 +7,16 @@
       # Primary external monior (centered)
       monitor=DP-3,3840x2160@30.00,6400x0,1
       # Primary monitor when run through TB3 dock
-      monitor=DP-8,3840x2160@60.00,6400x0,1
+      monitor=DP-7,3840x2160@60.00,6400x0,1
 
       # Secondary monitor (LEFT) when run through TB3 dock
-      monitor=DP-7,3840x2160@60.00,2560x0,1
+      monitor=DP-8,3840x2160@60.00,2560x0,1
 
       # Secondary external monitor. Place it to the right of primary & rotate 90 deg
-      #monitor=DP-2,3840x2160@60.00, 2560x0, 1, transform, 1
+      #monitor=DP-2,3840x2160@30.00, 2560x0, 1, transform, 1
       # Secondary external monitor. Place it to the right of primary (without rotation)
-      monitor=DP-2,3840x2160@60.00,10240x0, 1
+      monitor=DP-2,3840x2160@30.00,10240x0, 1
+      #monitor=DP-2,1920x1080@60.00,10240x0, 1
 
       # Tertiary external monitor. Place it using auto-layout
       monitor=DP-4,3840x2160@60.00, auto, 1

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -192,6 +192,7 @@
         # gimme-aws-creds # CLI wrapper for Okta/ SAML2.0 IDPs and AWS
         # github-desktop
         file-roller       # archive manager
+        gimp
         go                # go programming language
         grim              # simple screenshot tool while flameshot is broken
         hyprshot


### PR DESCRIPTION
- Fixes Okta MFA issues with Chromium and Chromium-based Browsers when `BlockThirdPartyCookies` = `true`
- Adds GIMP for image manipulation
- Updates to readme