### PR TITLE
0.1.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744145203,
-        "narHash": "sha256-I2oILRiJ6G+BOSjY+0dGrTPe080L3pbKpc+gCV3Nmyk=",
+        "lastModified": 1747742835,
+        "narHash": "sha256-kYL4GCwwznsypvsnA20oyvW8zB/Dvn6K5G/tgMjVMT4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "76c0a6dba345490508f36c1aa3c7ba5b6b460989",
+        "rev": "df522e787fdffc4f32ed3e1fca9ed0968a384d62",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1743420942,
-        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
+        "lastModified": 1747900541,
+        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
+        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744223888,
-        "narHash": "sha256-reYpe0J1J+wH34JFs7KKp0G5nP7+XSQ5z0ZLFJcfJr8=",
+        "lastModified": 1747978958,
+        "narHash": "sha256-pQQnbxWpY3IiZqgelXHIe/OAE/Yv4NSQq7fch7M6nXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79461936709b12e17adb9c91dd02d1c66d577f09",
+        "rev": "7419250703fd5eb50e99bdfb07a86671939103ea",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743420942,
-        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
+        "lastModified": 1747900541,
+        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
+        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744103455,
-        "narHash": "sha256-SR6+qjkPjGQG+8eM4dCcVtss8r9bre/LAxFMPJpaZeU=",
+        "lastModified": 1747603214,
+        "narHash": "sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD+9H+Wc8o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "69d5a5a4635c27dae5a742f36108beccc506c1ba",
+        "rev": "8d215e1c981be3aa37e47aeabd4e61bb069548fd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1741792691,
-        "narHash": "sha256-f0BVt1/cvA0DQ/q3rB+HY4g4tKksd03ZkzI4xehC2Ew=",
+        "lastModified": 1742806253,
+        "narHash": "sha256-zvQ4GsCJT6MTOzPKLmlFyM+lxo0JGQ0cSFaZSACmWfY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "e1f12151258b12c567f456d8248e4694e9390613",
+        "rev": "ecaa2d911e77c265c2a5bac8b583c40b0f151726",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741894454,
-        "narHash": "sha256-Mu2YXrGr/8Cid6W44AXci/YYnASoXjGrMV9Sjs66oyc=",
+        "lastModified": 1742842119,
+        "narHash": "sha256-YnJ1MHMLMDcWW4sRQya7IfXdJQAqW5y+lkL/WIvefc8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0b0baed7b2bf6a5e365d4cba042b580a2bc32e34",
+        "rev": "2d057cd9d4f767737498e0aae75b07353c75bdee",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1741792691,
-        "narHash": "sha256-f0BVt1/cvA0DQ/q3rB+HY4g4tKksd03ZkzI4xehC2Ew=",
+        "lastModified": 1742806253,
+        "narHash": "sha256-zvQ4GsCJT6MTOzPKLmlFyM+lxo0JGQ0cSFaZSACmWfY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "e1f12151258b12c567f456d8248e4694e9390613",
+        "rev": "ecaa2d911e77c265c2a5bac8b583c40b0f151726",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741861888,
-        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741786315,
-        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "lastModified": 1744145203,
+        "narHash": "sha256-I2oILRiJ6G+BOSjY+0dGrTPe080L3pbKpc+gCV3Nmyk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "rev": "76c0a6dba345490508f36c1aa3c7ba5b6b460989",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1742806253,
-        "narHash": "sha256-zvQ4GsCJT6MTOzPKLmlFyM+lxo0JGQ0cSFaZSACmWfY=",
+        "lastModified": 1743420942,
+        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "ecaa2d911e77c265c2a5bac8b583c40b0f151726",
+        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743097780,
-        "narHash": "sha256-5tUbaMBKYbfTe/4aXACxmiXG22TgwPBNcfZ8Kg3rt+g=",
+        "lastModified": 1744223888,
+        "narHash": "sha256-reYpe0J1J+wH34JFs7KKp0G5nP7+XSQ5z0ZLFJcfJr8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52",
+        "rev": "79461936709b12e17adb9c91dd02d1c66d577f09",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742806253,
-        "narHash": "sha256-zvQ4GsCJT6MTOzPKLmlFyM+lxo0JGQ0cSFaZSACmWfY=",
+        "lastModified": 1743420942,
+        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "ecaa2d911e77c265c2a5bac8b583c40b0f151726",
+        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742700801,
-        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "lastModified": 1744103455,
+        "narHash": "sha256-SR6+qjkPjGQG+8eM4dCcVtss8r9bre/LAxFMPJpaZeU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "rev": "69d5a5a4635c27dae5a742f36108beccc506c1ba",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738765162,
-        "narHash": "sha256-3Z40qHaFScWUCVQrGc4Y+RdoPsh1R/wIh+AN4cTXP0I=",
+        "lastModified": 1741786315,
+        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ff3568858c54bd306e9e1f2886f0f781df307dff",
+        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1738816619,
-        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
+        "lastModified": 1741792691,
+        "narHash": "sha256-f0BVt1/cvA0DQ/q3rB+HY4g4tKksd03ZkzI4xehC2Ew=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
+        "rev": "e1f12151258b12c567f456d8248e4694e9390613",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739287084,
-        "narHash": "sha256-CtRNJsqsXIArJV+AKWZVBMO8PD1FQB69br+WMtTJEgI=",
+        "lastModified": 1741894454,
+        "narHash": "sha256-Mu2YXrGr/8Cid6W44AXci/YYnASoXjGrMV9Sjs66oyc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f351726c5841d86854e7fa6003ea472352f5208",
+        "rev": "0b0baed7b2bf6a5e365d4cba042b580a2bc32e34",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738816619,
-        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
+        "lastModified": 1741792691,
+        "narHash": "sha256-f0BVt1/cvA0DQ/q3rB+HY4g4tKksd03ZkzI4xehC2Ew=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
+        "rev": "e1f12151258b12c567f456d8248e4694e9390613",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739020877,
-        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1739020877,
-        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739262228,
-        "narHash": "sha256-7JAGezJ0Dn5qIyA2+T4Dt/xQgAbhCglh6lzCekTVMeU=",
+        "lastModified": 1741861888,
+        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "07af005bb7d60c7f118d9d9f5530485da5d1e975",
+        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742842119,
-        "narHash": "sha256-YnJ1MHMLMDcWW4sRQya7IfXdJQAqW5y+lkL/WIvefc8=",
+        "lastModified": 1743097780,
+        "narHash": "sha256-5tUbaMBKYbfTe/4aXACxmiXG22TgwPBNcfZ8Kg3rt+g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d057cd9d4f767737498e0aae75b07353c75bdee",
+        "rev": "b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {

--- a/home/chrome/default.nix
+++ b/home/chrome/default.nix
@@ -130,8 +130,11 @@
       #"AudioCaptureAllowedUrls" = [];     # true = Specific URLs/patterns granting access to audio capture devices without prompt
       "AudioOutputAllowed" = true;      # true = enable audio output
       "AudioSandboxEnabled" = null;     # true = Always sandbox the process, false = never, not set = use default
-      "BlockThirdPartyCookies" = false;  # true = Block 3rd party cookies
-      "CookiesAllowedForUrls" = [];
+      "BlockThirdPartyCookies" = true;  # true = Block 3rd party cookies
+      "CookiesAllowedForUrls" = [       # NOTE: With BlockThirdPartyCookies = true, you must explicitly authorize cookies
+        "[*.]oktacdn.com"               #       for certain sites (like Otka), or functionalities like MFA / TOIP / FIDO auth will break.
+        "[*.]okta.com"                  #       These two entries fix MFA issues with Otka
+      ];
       "BrowserAddPersonEnabled" = true; # true = Allows adding a person to the user manager
       "BrowserLabsEnabled" = false;     # true = Users can access browser experimental features
       "BrowserSignIn" = 1;              # 0 = Disable, 1=Enable, 2=Force sign-in

--- a/home/chrome/default.nix
+++ b/home/chrome/default.nix
@@ -130,11 +130,8 @@
       #"AudioCaptureAllowedUrls" = [];     # true = Specific URLs/patterns granting access to audio capture devices without prompt
       "AudioOutputAllowed" = true;      # true = enable audio output
       "AudioSandboxEnabled" = null;     # true = Always sandbox the process, false = never, not set = use default
-      "BlockThirdPartyCookies" = true;  # true = Block 3rd party cookies
-      "CookiesAllowedForUrls" = [       # NOTE: With BlockThirdPartyCookies = true, you must explicitly authorize cookies
-        "[*.]oktacdn.com"               #       for certain sites (like Otka), or functionalities like MFA / TOIP / FIDO auth will break.
-        "[*.]okta.com"                  # These two entries fix MFA issues with Otka
-      ];
+      "BlockThirdPartyCookies" = false;  # true = Block 3rd party cookies
+      "CookiesAllowedForUrls" = [];
       "BrowserAddPersonEnabled" = true; # true = Allows adding a person to the user manager
       "BrowserLabsEnabled" = false;     # true = Users can access browser experimental features
       "BrowserSignIn" = 1;              # 0 = Disable, 1=Enable, 2=Force sign-in

--- a/home/firefox/default.nix
+++ b/home/firefox/default.nix
@@ -81,6 +81,11 @@
           install_url = "https://addons.mozilla.org/firefox/downloads/latest/privacy-badger17/latest.xpi";
           installation_mode = "force_installed";
         };
+        # SAML-tracer:
+        "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}" = {
+          install_url = "https://addons.mozilla.org/firefox/downloads/latest/saml-tracer/latest.xpi";
+          installation_mode = "force_installed";
+        };
       };
       FirefoxHome = {
         Search = true;

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -174,7 +174,7 @@ master {
 ## not working, check script TODO
 
 # bind = $mainMod, F, exec, firefox                      # imported from ../firefox
-bind = $mainMod, J, exec, joplin-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland       # TODO - move to home
+bind = $mainMod, J, exec, env -u NIXOS_OZONE_WL joplin-desktop --enable-features=UseOzonePlatform --ozone-platform=wayland       # TODO - move to home
 bind = $mainMod, L, exec, pidof hyprlock || hyprlock
 # bind = $mainMod, L, exec, swaylock                     # imported from ../swaylock
 # bind = $mainMod, O, exec, obs                          # imported from ../obs-studio

--- a/home/kitty/default.nix
+++ b/home/kitty/default.nix
@@ -48,9 +48,9 @@
         windowrulev2 = tile, class:^(kitty)$
         bind = $mainMod, Q, exec, kitty
         bind = control, escape, exec, kitty -e btm
-        windowrule = tile, title:zsh
-        windowrule=tile,^(kitty)$
-        windowrule=tile,title:^(kitty)(.*)$
+        #windowrule = tile, title:zsh
+        #windowrule=tile,^(kitty)$
+        #windowrule=tile,title:^(kitty)(.*)$
       '';
     };
   };

--- a/home/vscode/default.nix
+++ b/home/vscode/default.nix
@@ -6,16 +6,16 @@
 }: {
   home-manager.users.${user}.programs.vscode = {
     enable = true;
-    enableExtensionUpdateCheck = true;
-    enableUpdateCheck = true;
+    profiles.default.enableExtensionUpdateCheck = true;
+    profiles.default.enableUpdateCheck = true;
     package = pkgs.vscodium; # pkgs.vscodium or pkgs.vscode (default)
 
-    extensions = [
+    profiles.default.extensions = [
       pkgs.vscode-extensions.bbenoist.nix
       #pkgs.vscode-extensions.bridgecrew.checkov                   # Does not exist, using workaround solution below
       pkgs.vscode-extensions.continue.continue
       pkgs.vscode-extensions.esbenp.prettier-vscode
-      pkgs.vscode-extensions.equinusocio.vsc-material-theme
+      #pkgs.vscode-extensions.equinusocio.vsc-material-theme # SOME CONCERN ABOUT COMPROMISE - DISABLING UNTIL CONFIRMED
       #pkgs.vscode-extensions.equinusocio.vsc-material-theme-icons # Does not exist
       pkgs.vscode-extensions.golang.go
       pkgs.vscode-extensions.hashicorp.terraform
@@ -74,11 +74,11 @@
       #   # sha256sum Continue.continue-0.9.211@linux-x64.vsix
       # }
     ];
-    globalSnippets = {};
+    profiles.default.globalSnippets = {};
     haskell.enable = false;
-    keybindings = [];
+    profiles.default.keybindings = [];
     mutableExtensionsDir = false; # Whether extensions can be installed or updated manually or by VS Code
-    userSettings = {
+    profiles.default.userSettings = {
       checkov = {
         checkovVersion = "latest";
         prismaURL = "https://api4.prismacloud.io";

--- a/home/vscode/default.nix
+++ b/home/vscode/default.nix
@@ -13,7 +13,8 @@
     profiles.default.extensions = [
       pkgs.vscode-extensions.bbenoist.nix
       #pkgs.vscode-extensions.bridgecrew.checkov                   # Does not exist, using workaround solution below
-      pkgs.vscode-extensions.continue.continue
+      pkgs.vscode-extensions.saoudrizwan.claude-dev
+      #pkgs.vscode-extensions.continue.continue                    # REPLACED WITH CLAUDE-DEV (CLINE)
       pkgs.vscode-extensions.esbenp.prettier-vscode
       #pkgs.vscode-extensions.equinusocio.vsc-material-theme       # SOME CONCERN ABOUT DEPENDENCY COMPROMISE - DISABLING
       #pkgs.vscode-extensions.equinusocio.vsc-material-theme-icons # SOME CONCERN ABOUT DEPENDENCY COMPROMISE - DISABLING
@@ -321,6 +322,9 @@
       };
       update = {
         showReleaseNotes = false;
+      };
+      vsicons = {
+        dontShowNewVersionMessage = true;
       };
       window = {
         zoomLevel = 1;

--- a/home/vscode/default.nix
+++ b/home/vscode/default.nix
@@ -15,8 +15,8 @@
       #pkgs.vscode-extensions.bridgecrew.checkov                   # Does not exist, using workaround solution below
       pkgs.vscode-extensions.continue.continue
       pkgs.vscode-extensions.esbenp.prettier-vscode
-      #pkgs.vscode-extensions.equinusocio.vsc-material-theme # SOME CONCERN ABOUT COMPROMISE - DISABLING UNTIL CONFIRMED
-      #pkgs.vscode-extensions.equinusocio.vsc-material-theme-icons # Does not exist
+      #pkgs.vscode-extensions.equinusocio.vsc-material-theme       # SOME CONCERN ABOUT DEPENDENCY COMPROMISE - DISABLING
+      #pkgs.vscode-extensions.equinusocio.vsc-material-theme-icons # SOME CONCERN ABOUT DEPENDENCY COMPROMISE - DISABLING
       pkgs.vscode-extensions.golang.go
       pkgs.vscode-extensions.hashicorp.terraform
       pkgs.vscode-extensions.ms-azuretools.vscode-docker
@@ -112,7 +112,7 @@
         renderControlCharacters = false;
         tabSize = 2;
         tokenColorCustomizations = {
-          "[Material Theme Ocean High Contrast]" = {
+          "[Dark Modern]" = {
             comments = "#5a5a5a";
             functions = "#b300ea";
             strings = "#19c1db";
@@ -395,7 +395,7 @@
           textLink = {
             foreground = "#80CBC4";
           };
-          "[Material Theme Ocean High Contrast]" = {
+          "[Dark Modern]" = {
             activityBar = {
               activeBackground = "#081a1b";
               background = "#000000";
@@ -439,9 +439,9 @@
           };
         };
         closeOnFileDelete = true;
-        colorTheme = "Material Theme Ocean High Contrast";
+        colorTheme = "Dark Modern";
         iconTheme = "vscode-icons";
-        preferredDarkColorTheme = "Material Theme Ocean High Contrast";
+        preferredDarkColorTheme = "Dark Modern";
         statusBar = {
           visible = true;
         };

--- a/hosts/fw16-nix/hardware-configuration.nix
+++ b/hosts/fw16-nix/hardware-configuration.nix
@@ -67,7 +67,7 @@
     #"pci-stub.ids=1002:7480,1002:ab30"
     "mem_sleep_default=deep" # Fix for AMD-related power-draw while syspended/sleeping
   ];
-  boot.kernelPackages = pkgs.linuxPackages_6_12; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
+  boot.kernelPackages = pkgs.linuxPackages_6_13; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
   boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];# Used for OBS virtual cameras as Zoom screen sharing workaround
 
   swapDevices = [ ];

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -7,10 +7,10 @@
       # Primary external monior (centered)
       monitor=DP-3,3840x2160@30.00,6400x0,1
       # Primary monitor when run through TB3 dock
-      monitor=DP-7,3840x2160@60.00,6400x0,1
+      monitor=DP-8,3840x2160@60.00,6400x0,1
 
       # Secondary monitor (LEFT) when run through TB3 dock
-      monitor=DP-8,3840x2160@60.00,2560x0,1
+      monitor=DP-7,3840x2160@60.00,2560x0,1
 
       # Secondary external monitor. Place it to the right of primary & rotate 90 deg
       #monitor=DP-2,3840x2160@30.00, 2560x0, 1, transform, 1

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -278,25 +278,11 @@
       #pipewire-zoom
       polkit_gnome
       python3
-      python312Packages.boto3
-      python312Packages.boto3-stubs
-      python312Packages.botocore
-      python312Packages.jinja2-ansible-filters
-      python312Packages.pip
-      #python311Packages.setuptools
-      #python311Packages.virtualenv
-      python312Packages.xmltodict
       (python3.withPackages(ps: with ps; [
-        jq pip requests docker botocore boto3
+        jq pip requests docker botocore boto3 boto3-stubs jinja2-ansible-filters xmltodict
       ]))
-      (python312.withPackages(ps: with ps; [
-        jq pip requests docker botocore boto3
-      ]))
-      #python311Packages.wheel
       #qt6.qtwayland # SecureCRT dependency
       ssm-session-manager-plugin # AWS Systems Manager Session Manager plugin
-      #swayidle # Replaced with hyprlock
-      #swaylock # Replaced with hypridle
       tailscale
       terraform
       terraform-docs

--- a/modules/audio/default.nix
+++ b/modules/audio/default.nix
@@ -4,11 +4,11 @@
   user,
   ...
 }: {
-  home-manager.users.${user}.home.file.".config/hypr/per-app/audio.conf" = {
-    text = ''
-      windowrule = float, ^(pavucontrol)$
-    '';
-  };
+  # home-manager.users.${user}.home.file.".config/hypr/per-app/audio.conf" = {
+  #   text = ''
+  #     windowrule = float, pavucontrol
+  #   '';
+  # };
   users.users.${user}.packages = with pkgs; [pamixer pavucontrol];
   security.rtkit.enable = true;       # used by PulseAudio to acquire realtime priority
   #sound.enable = true;               # Not intended to be enabled with Pipewire. Disable to fix alsa-store.service failure on rebuild. See https://github.com/NixOS/nixpkgs/issues/319809

--- a/pkgs/globalprotect/gpauth.nix
+++ b/pkgs/globalprotect/gpauth.nix
@@ -12,7 +12,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gpauth";
-  version = "2.4.1";
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "yuezk";
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   buildAndTestSubdir = "apps/gpauth";
-  cargoHash = "sha256-bZhLSKoki9aLEG+jmieCUitvR5mIfntzi+XcMJqyv3s=";
+  cargoHash = "sha256-JR7COu/xbpO43cJ25MvQ0qT1hovY+VT8LeqZiizJims=";
 
   nativeBuildInputs = [
     perl

--- a/pkgs/globalprotect/gpauth.nix
+++ b/pkgs/globalprotect/gpauth.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   buildAndTestSubdir = "apps/gpauth";
-  cargoHash = "sha256-JR7COu/xbpO43cJ25MvQ0qT1hovY+VT8LeqZiizJims=";
+  cargoHash = "sha256-8LSGuRnWRWeaY6t25GdZ2y4hGIJ+mP3UBXRjcvPuD6U=";
 
   nativeBuildInputs = [
     perl

--- a/pkgs/globalprotect/gpclient.nix
+++ b/pkgs/globalprotect/gpclient.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   inherit (gpauth) version src meta;
 
   buildAndTestSubdir = "apps/gpclient";
-  cargoHash = "sha256-aanC0iwitvpKWCZSyaGVIkrWo/Hi1gjS19t3PfW+w4U=";
+  cargoHash = "sha256-Flig4GTYW3WWAsaO1FT0XXbG8tDnFM3Lz6recRVl3Zg=";
 
   nativeBuildInputs = [ perl jq webkitgtk_4_1 libsoup_3 pkg-config ];
   PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";

--- a/pkgs/globalprotect/gpclient.nix
+++ b/pkgs/globalprotect/gpclient.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   inherit (gpauth) version src meta;
 
   buildAndTestSubdir = "apps/gpclient";
-  cargoHash = "sha256-Flig4GTYW3WWAsaO1FT0XXbG8tDnFM3Lz6recRVl3Zg=";
+  cargoHash = "sha256-8LSGuRnWRWeaY6t25GdZ2y4hGIJ+mP3UBXRjcvPuD6U=";
 
   nativeBuildInputs = [ perl jq webkitgtk_4_1 libsoup_3 pkg-config ];
   PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";


### PR DESCRIPTION
- [fix hyprland windowrulev2 issues with kitty and pavucontrol](https://github.com/psiri/nixos-config/commit/0d7486b4545807666c72d70167d2870ffd0ec8c2)

- [bump kernel to 6.13 and cleanup config](https://github.com/psiri/nixos-config/commit/92b789e6db042d79cd6f7082e2555c59de334787)
- [bump globalprotect-openconnect packages to 2.4.4, replace continue with claude-dev(https://github.com/psiri/nixos-config/commit/76232a27fd23e7e1e2e9affd9eeefec77c381eed)
- [fix joplin-desktop error: "Unknown flag: --enable-wayland-ime=true"](https://github.com/psiri/nixos-config/commit/38475492233260fab2234f94dd5bb2a99aa93c02)

