### PR TITLE
0.1.9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747742835,
-        "narHash": "sha256-kYL4GCwwznsypvsnA20oyvW8zB/Dvn6K5G/tgMjVMT4=",
+        "lastModified": 1748832438,
+        "narHash": "sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "df522e787fdffc4f32ed3e1fca9ed0968a384d62",
+        "rev": "58d6e5a83fff9982d57e0a0a994d4e5c0af441e4",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1747900541,
-        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
+        "lastModified": 1748942041,
+        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
+        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747978958,
-        "narHash": "sha256-pQQnbxWpY3IiZqgelXHIe/OAE/Yv4NSQq7fch7M6nXQ=",
+        "lastModified": 1748955489,
+        "narHash": "sha256-OmZXyW2g5qIuo5Te74McwR0TwauCO2sF3/SjGDVuxyg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7419250703fd5eb50e99bdfb07a86671939103ea",
+        "rev": "bb846c031be68a96466b683be32704ef6e07b159",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747900541,
-        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
+        "lastModified": 1748942041,
+        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
+        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752718651,
-        "narHash": "sha256-PkaR0qmyP9q/MDN3uYa+RLeBA0PjvEQiM0rTDDBXkL8=",
+        "lastModified": 1755519972,
+        "narHash": "sha256-bU4nqi3IpsUZJeyS8Jk85ytlX61i4b0KCxXX9YcOgVc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d5ad4485e6f2edcc06751df65c5e16572877db88",
+        "rev": "4073ff2f481f9ef3501678ff479ed81402caae6d",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1752666637,
-        "narHash": "sha256-P8J72psdc/rWliIvp8jUpoQ6qRDlVzgSDDlgkaXQ0Fw=",
+        "lastModified": 1755330281,
+        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "d1bfa8f6ccfb5c383e1eba609c1eb67ca24ed153",
+        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752814804,
-        "narHash": "sha256-irfg7lnfEpJY+3Cffkluzp2MTVw1Uq9QGxFp6qadcXI=",
+        "lastModified": 1755625756,
+        "narHash": "sha256-t57ayMEdV9g1aCfHzoQjHj1Fh3LDeyblceADm2hsLHM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0300c8808e41da81d6edfc202f3d3833c157daf",
+        "rev": "dd026d86420781e84d0732f2fa28e1c051117b59",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1752666637,
-        "narHash": "sha256-P8J72psdc/rWliIvp8jUpoQ6qRDlVzgSDDlgkaXQ0Fw=",
+        "lastModified": 1755330281,
+        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "d1bfa8f6ccfb5c383e1eba609c1eb67ca24ed153",
+        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
+        "lastModified": 1754988908,
+        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
+        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748832438,
-        "narHash": "sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A=",
+        "lastModified": 1752718651,
+        "narHash": "sha256-PkaR0qmyP9q/MDN3uYa+RLeBA0PjvEQiM0rTDDBXkL8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "58d6e5a83fff9982d57e0a0a994d4e5c0af441e4",
+        "rev": "d5ad4485e6f2edcc06751df65c5e16572877db88",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1748942041,
-        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
+        "lastModified": 1752666637,
+        "narHash": "sha256-P8J72psdc/rWliIvp8jUpoQ6qRDlVzgSDDlgkaXQ0Fw=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
+        "rev": "d1bfa8f6ccfb5c383e1eba609c1eb67ca24ed153",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748955489,
-        "narHash": "sha256-OmZXyW2g5qIuo5Te74McwR0TwauCO2sF3/SjGDVuxyg=",
+        "lastModified": 1752814804,
+        "narHash": "sha256-irfg7lnfEpJY+3Cffkluzp2MTVw1Uq9QGxFp6qadcXI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bb846c031be68a96466b683be32704ef6e07b159",
+        "rev": "d0300c8808e41da81d6edfc202f3d3833c157daf",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1748942041,
-        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
+        "lastModified": 1752666637,
+        "narHash": "sha256-P8J72psdc/rWliIvp8jUpoQ6qRDlVzgSDDlgkaXQ0Fw=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
+        "rev": "d1bfa8f6ccfb5c383e1eba609c1eb67ca24ed153",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747603214,
-        "narHash": "sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD+9H+Wc8o=",
+        "lastModified": 1752544651,
+        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8d215e1c981be3aa37e47aeabd4e61bb069548fd",
+        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755519972,
-        "narHash": "sha256-bU4nqi3IpsUZJeyS8Jk85ytlX61i4b0KCxXX9YcOgVc=",
+        "lastModified": 1756115622,
+        "narHash": "sha256-iv8xVtmLMNLWFcDM/HcAPLRGONyTRpzL9NS09RnryRM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4073ff2f481f9ef3501678ff479ed81402caae6d",
+        "rev": "bafad29f89e83b2d861b493aa23034ea16595560",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1755330281,
-        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
+        "lastModified": 1756245047,
+        "narHash": "sha256-9bHzrVbjAudbO8q4vYFBWlEkDam31fsz0J7GB8k4AsI=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
+        "rev": "a65b650d6981e23edd1afa1f01eb942f19cdcbb7",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755625756,
-        "narHash": "sha256-t57ayMEdV9g1aCfHzoQjHj1Fh3LDeyblceADm2hsLHM=",
+        "lastModified": 1756496801,
+        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd026d86420781e84d0732f2fa28e1c051117b59",
+        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1755330281,
-        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
+        "lastModified": 1756245047,
+        "narHash": "sha256-9bHzrVbjAudbO8q4vYFBWlEkDam31fsz0J7GB8k4AsI=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
+        "rev": "a65b650d6981e23edd1afa1f01eb942f19cdcbb7",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {
@@ -171,10 +171,10 @@
     "private-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1739291321,
-        "narHash": "sha256-CQk82+4s2Qg+CrZ8/QpEmgF5dqJf/KxMzT9Lljjv+HI=",
+        "lastModified": 1756579167,
+        "narHash": "sha256-9F1fjLv0RakiEtc4AscKMzE7a3dRytaFNX4xXK0EDmk=",
         "ref": "main",
-        "rev": "7c8b91aa738ecc51f883539281d3b2e41c4fc388",
+        "rev": "50d723fd1976e12650a3019d5a9832fe32f821c6",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/psiri/nixos-secrets.git"

--- a/home/hypr/hyprland.nix
+++ b/home/hypr/hyprland.nix
@@ -184,6 +184,7 @@ bind = $mainMod SHIFT, S, exec, env QT_QPA_PLATFORM_PLUGIN_PATH="/home/psiri/Doc
 # bind = $mainMod, SPACE, exec, $menu                    # imported from ../ulauncher
 # bind = $mainMod, W, exec, chromium                     # imported from ../chrome
 bind = $mainMod, R, exec, remmina
+# bind = $mainMod CTRL SHIFT, R, exec, pkill waybar && hyprctl dispatch exec waybar # imported from ../waybar
 bind = $mainMod, S, exec, slack
 bind = $mainMod, T, exec, teams-for-linux
 bind = $mainMod, V, exec, $VSCODE_APP

--- a/home/tailscale/default.nix
+++ b/home/tailscale/default.nix
@@ -7,8 +7,28 @@
   lib,
   ...
 }: {
+  # sops.secrets.tailscale_auth_key = {
+  #   #sopsFile = ./secrets.yaml; # Path to your encrypted secrets file
+  #   key = "tailscale_auth_key"; # The key within your YAML file holding the auth key
+  #   owner = "root";
+  #   mode = "0400"; # Read-only for the owner
+  # };
+
+  #sops.templates."tailscale_auth_key".path = "/etc/tailscale/tskey-reusable";
+  sops.templates."tailscale_auth_key".owner = "root";
+  sops.templates."tailscale_auth_key".mode = "0600";
+  sops.templates."tailscale_auth_key".content = ''
+  ${config.sops.placeholder.tailscale_auth_key}
+    '';
+
   services.tailscale = {
     enable = true;
+    disableTaildrop = false;
+    openFirewall = false;
     useRoutingFeatures = "client";
+    # Use the path to the decrypted secret provided by sops-nix
+    authKeyFile = ${config.sops.secrets.tailscale_auth_key.path};
+    authKeyParameters.ephemeral = false;
+    authKeyParameters.preauthorized = true;
   };
 }

--- a/home/vscode/default.nix
+++ b/home/vscode/default.nix
@@ -19,7 +19,7 @@
       #pkgs.vscode-extensions.equinusocio.vsc-material-theme       # SOME CONCERN ABOUT DEPENDENCY COMPROMISE - DISABLING
       #pkgs.vscode-extensions.equinusocio.vsc-material-theme-icons # SOME CONCERN ABOUT DEPENDENCY COMPROMISE - DISABLING
       pkgs.vscode-extensions.golang.go
-      pkgs.vscode-extensions.hashicorp.terraform
+      #pkgs.vscode-extensions.hashicorp.terraform
       pkgs.vscode-extensions.ms-azuretools.vscode-docker
       #pkgs.vscode-extensions.ms-python.python
       pkgs.vscode-extensions.ms-python.vscode-pylance
@@ -74,6 +74,17 @@
       #   # Then run the following command to determine the sha256 checksum:
       #   # sha256sum Continue.continue-0.9.211@linux-x64.vsix
       # }
+      {
+        name = "terraform";
+        publisher = "hashicorp";
+        version = "2.34.5";
+        sha256 = "b7950b781d23be4b7d6b59b7800e43bb42a5d4523566772ac804255c1c32c9f1";
+        # ! IMPORTANT ! The sha256 checksum is matched against the packages from the official visual studio marketplace
+        # Download from https://marketplace.visualstudio.com/items?itemName=hashicorp.terraform (or your desired extension)
+        # Then run the following command to determine the sha256 checksum:
+        # sha256sum hashicorp.terraform-2.34.5.vsix
+        # https://open-vsx.org/api/hashicorp/terraform
+      }
     ];
     profiles.default.globalSnippets = {};
     haskell.enable = false;
@@ -102,11 +113,12 @@
       editor = {
         accessibilitySupport = "off";
         cursorWidth = 2;
+        defaultFormatter= "esbenp.prettier-vscode";
         fontFamily = "Hack Nerd Font";     
         fontLigatures = true;
         fontSize = 11;
         formatOnSave = true;
-        formatOnSaveMode = "modificationsIfAvailable";
+        formatOnSaveMode = "file";
         minimap = {
           enabled = false;
         };
@@ -228,6 +240,10 @@
         confirmDelete = false;
         confirmDragAndDrop = false;
       };
+      files.associations = {
+        "*.hcl" = "terraform";
+        "*.tf" = "terraform";
+      };
       git = {
         autofetch = true;
         confirmSync = false;
@@ -286,17 +302,64 @@
           scrollback = 3000;
         };
       };
+      scm.repositories.visible = 50;
+      terraform = {
+        editor = {
+          defaultFormatter = "hashicorp.terraform";
+          formatOnSave = true;
+          formatOnSaveMode = "file";
+          codeActionsOnSave = {
+            source.formatAll.terraform = true;
+          };
+        };
+        languageServer = {
+          enable = true;
+          path = "/run/current-system/sw/bin/terraform-ls";
+        };
+        experimentalFeatures = {
+          validateOnSave = false;
+        };
+        telemetry = {
+          enabled = false;
+          telemetryLevel = "off";
+        };
+      };
+      terraform-vars = {
+        editor = {
+          defaultFormatter = "hashicorp.terraform";
+          formatOnSave = true;
+          formatOnSaveMode = "file";
+          codeActionsOnSave = {
+            source.formatAll.terraform = true;
+          };
+        };
+        languageServer = {
+          enable = true;
+          path = "/run/current-system/sw/bin/terraform-ls";
+        };
+        experimentalFeatures = {
+          validateOnSave = false;
+        };
+        telemetry = {
+          enabled = false;
+          telemetryLevel = "off";
+        };
+      };
       "[terraform]" = {
         editor = {
           defaultFormatter = "hashicorp.terraform";
           formatOnSave = true;
           formatOnSaveMode = "file";
+          codeActionsOnSave = {
+            source.formatAll.terraform = true;
+          };
         };
         languageServer = {
           enable = true;
+          path = "/run/current-system/sw/bin/terraform-ls";
         };
         experimentalFeatures = {
-          validateOnSave = true;
+          validateOnSave = false;
         };
         telemetry = {
           enabled = false;
@@ -308,12 +371,16 @@
           defaultFormatter = "hashicorp.terraform";
           formatOnSave = true;
           formatOnSaveMode = "file";
+          codeActionsOnSave = {
+            source.formatAll.terraform = true;
+          };
         };
         languageServer = {
           enable = true;
+          path = "/run/current-system/sw/bin/terraform-ls";
         };
         experimentalFeatures = {
-          validateOnSave = true;
+          validateOnSave = false;
         };
         telemetry = {
           enabled = false;

--- a/home/waybar/config.jsonc.nix
+++ b/home/waybar/config.jsonc.nix
@@ -55,6 +55,7 @@
           // "pulseaudio#microphone",
           "pulseaudio#audio",
           "battery",
+          "power-profiles-daemon",
           "tray"
         ],
 
@@ -96,7 +97,7 @@
           "interval": 1,
           "on-click": "",
           "tooltip": true,
-          "tooltip-format": "Used: {used} GiB ({percentage}%) / {total} GiB\nAvailable: {avail} GiB / {total} GiB\n Swap: {swapUsed} GiB ({swapPercentage}%) / {swapAvail} GiB"
+          "tooltip-format": "Used: {used} GiB ({percentage}%) / {total} GiB\nAvailable: {avail} GiB / {total} GiB\nSwap: {swapUsed} GiB ({swapPercentage}%) / {swapAvail} GiB"
         },
 
         "backlight": {
@@ -128,48 +129,59 @@
 
         "network": {
           "interval": 1,
-          // use auto-detection "interface": "wlp5s0",
-          "format-icons": [
-            "󰤯",
-            "󰤟",
-            "󰤢",
-            "󰤥",
-            "󰤨"
-          ],
-          "format-wifi": "󰞒 {bandwidthDownBytes} | 󰞕 {bandwidthUpBytes} {icon} {essid} ({signalStrength}%)",
-          "format-disconnected": "", // empty format hides the module
+          // use auto-detection. uncomment and specify to override "interface": "",
+          "family": "ipv4_6",
+          "format-wifi": "󰞒 {bandwidthDownBits} | 󰞕 {bandwidthUpBits} {icon} {essid} ({signalStrength}%)",
+          "format-ethernet": "󰞒 {bandwidthDownBits} | 󰞕 {bandwidthUpBits} {icon} {ifname} ",
+          "format-linked": "󰞒 {bandwidthDownBits} | 󰞕 {bandwidthUpBits} {icon} {ifname}",
           "format-disconnected": "󰤮",
-          "format-ethernet": "󰞒 {bandwidthDownBytes} | 󰞕 {bandwidthUpBytes} {icon} {ifname} ", 
+          "format-disabled": "", // hide module
+          "format-icons": {
+            "wifi": [
+              "󰤯",
+              "󰤟",
+              "󰤢",
+              "󰤥",
+              "󰤨"
+            ],
+            "ethernet": [
+              "󰈀",
+              "󰈀"
+            ]
+          },
           "on-click": "kitty --class nmwui nmtui",
           "tooltip": true,
-          "tooltip-format": "󰢮 {ifname}\n󰩟 {ipaddr}/{cidr}\n󰩟 Gateway: {gwaddr}\nNetmask: {netmask}\n{icon} {essid}\n󱑽 {signalStrength}% {signaldBm} dBm {frequency} MHz\n󰞒 {bandwidthDownBytes}\n󰞕 {bandwidthUpBytes}",
-          "tooltip-format-disconnected": "Disconnected",
-          "tooltip-format-disabled": "Disabled",
-          "tooltip-format-ethernet": "󰢮 {ifname}\n󰩟 {ipaddr}/{cidr}\n󰩟 Gateway: {gwaddr}\nNetmask: {netmask}\n󰞒 {bandwidthDownBytes}\n󰞕 {bandwidthUpBytes}",
-          "tooltip-format-wifi": "󰢮 {ifname}\n󰩟 {ipaddr}/{cidr}\n󰩟 Gateway: {gwaddr}\nNetmask: {netmask}\n{icon} {essid}\n󱑽 {signalStrength}% {signaldBm} dBm {frequency} MHz\n󰞒 {bandwidthDownBytes}\n󰞕 {bandwidthUpBytes}"
+          "tooltip-format-disconnected": "{icon} {ifname}\nStatus: Disconnected",
+          "tooltip-format-disabled": "{icon} {ifname}\nStatus: Disabled",
+          "tooltip-format": "{icon} {ifname}\nIPv4: {ipaddr}IPv4 CIDR: /{cidr}\nIPv4 Netmask: {netmask}\nIPv6 CIDR: {cidr6}\nIPv6 Netmask: /{netmask6}\nGateway: {gwaddr}\n{icon} {essid}\n󱑽 {signalStrength}% {signaldBm} dBm {frequency} GHz\n󰞒 {bandwidthDownBits}\n󰞕 {bandwidthUpBits}",
+          "tooltip-format-ethernet": "{icon} {ifname}\nIPv4: {ipaddr}IPv4 CIDR: /{cidr}\nIPv4 Netmask: {netmask}\nIPv6 CIDR: {cidr6}\nIPv6 Netmask: /{netmask6}\nGateway: {gwaddr}\n󰞒 {bandwidthDownBits}\n󰞕 {bandwidthUpBits}",
+          "tooltip-format-wifi": "{icon} {ifname}\nIPv4: {ipaddr}IPv4 CIDR: /{cidr}\nIPv4 Netmask: {netmask}\nIPv6 CIDR: {cidr6}\nIPv6 Netmask: /{netmask6}\nGateway: {gwaddr}\n{icon} {essid}\n󱑽 {signalStrength}% {signaldBm} dBm {frequency} GHz\n󰞒 {bandwidthDownBits}\n󰞕 {bandwidthUpBits}"
         },
 
         "bluetooth": {
-          "format-disabled": " 󰂲 ",
-          "format-off": " 󰂲 ",
-          "format-on": " 󰂯 ",
-          "format-connected": " 󰂯 ",
-          "format-connected-battery": " 󰂯 ",
-          "format-no-controller": "",
-          "tooltip-format-connected": " {device_alias} 󰂄{device_battery_percentage} ",
+          "format": "󰂲 {status}",
+          "format-disabled": "󰂲 sw-disabled",
+          "format-off": "󰂲 off",
+          "format-on": "󰂯",
+          "format-connected": "󰂯",
+          "format-connected-battery": "󰂯",
+          "format-no-controller": "󰂲 hw-disabled",
+          "tooltip-format-connected": "{device_alias} 󰂄{device_battery_percentage}",
           "on-click": "bluez",
-          "tooltip": true
+          "tooltip": false
         },
 
         "battery": {
+          "interval": 60,
           "states": {
-            "warning": 20,
-            "critical": 10
+            "warning": 25,
+            "critical": 15
           },
 
-          "format": " {icon} {capacity} ",
-          "format-charging": " 󰂄 {capacity} ",
-          "format-plugged": " 󱘖 {capacity} ",
+          "format": "{icon} {capacity}%",
+          "format-charging": "󰂄 {capacity}% {time}",
+          "format-plugged": "󱘖 {capacity}% {time}",
+          "format-time": "{H} h {M} min",
           "format-icons": [
             "󰁺",
             "󰁻",
@@ -183,8 +195,22 @@
             "󰁹"
           ],
           "on-click": "",
-          "tooltip": false
+          "tooltip": false,
+          "tooltip-format": "{icon}\nCapacity: {capacity}\nTime to Full/Empty: {time}\nPower Draw (w): {power}\nCycles: {cycles}"
+        },
+
+        "power-profiles-daemon": {
+          "format": "{icon}",
+          "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
+          "tooltip": true,
+          "format-icons": {
+            "default": "",
+            "performance": "",
+            "balanced": "",
+            "power-saver": ""
+          }
         }
+
       }
 
     '';

--- a/home/waybar/default.nix
+++ b/home/waybar/default.nix
@@ -18,5 +18,10 @@
         exec-once = waybar
       '';
     };
+    home.file.".config/hypr/per-app/waybar-reload.conf" = {
+      text = ''
+        bind = $mainMod CTRL SHIFT, R, exec, pkill waybar && hyprctl dispatch exec waybar
+      '';
+    };
   };
 }

--- a/home/waybar/style.css.nix
+++ b/home/waybar/style.css.nix
@@ -115,22 +115,14 @@
 
       /* -------------------------------------------------------------------------------- */
 
-      #custom-launcher,
-      /* #window, */
-      #submap
-      #mode,
-      /* #tray, */
-      #cpu { background-color: #${config.colorScheme.palette.base00}; }
-      #memory { background-color: #${config.colorScheme.palette.base00}; }
-      #backlight,
-      #window  { background-color: #${config.colorScheme.palette.base00}; }
-      #pulseaudio.audio { background-color: #${config.colorScheme.palette.base00}; }
-      #pulseaudio.microphone,
-      #network { background-color: #${config.colorScheme.palette.base00}; }
-      #bluetooth  { background-color: #${config.colorScheme.palette.base00}; }
-      #battery  { background-color: #${config.colorScheme.palette.base00}; }
-      #clock { background-color: #${config.colorScheme.palette.base00}; }
-      #custom-powermenu,
+      #cpu, #memory, #backlight, #window, #pulseaudio, #network, #bluetooth, #battery, #power-profiles-daemon, #clock, #submap, #mode, #custom-launcher, #custom-powermenu {
+        background-color: #${config.colorScheme.palette.base00};
+      }
+
+      #cpu:hover, #memory:hover, #backlight:hover, #window:hover, #pulseaudio:hover, #network:hover, #bluetooth:hover, #battery:hover, #power-profiles-daemon:hover, #clock:hover, #submap:hover, #mode:hover, #custom-launcher:hover, #custom-powermenu:hover {
+        background-color: #${config.colorScheme.palette.base04};
+        color: #${config.colorScheme.palette.base09};
+      }
 
       #custom-notification {
         background-color: transparent;
@@ -164,6 +156,7 @@
       .modules-left > widget:first-child > #network,
       .modules-left > widget:first-child > #bluetooth,
       .modules-left > widget:first-child > #battery,
+      .modules-left > widget:first-child > #power-profiles-daemon,
       .modules-left > widget:first-child > #clock,
       .modules-left > widget:first-child > #custom-powermenu,
       .modules-left > widget:first-child > #custom-notification {
@@ -186,6 +179,7 @@
       .modules-right > widget:last-child > #pulseaudio.microphone,
       .modules-right > widget:last-child > #bluetooth,
       .modules-right > widget:last-child > #battery,
+      .modules-right > widget:last-child > #power-profiles-daemon,
       .modules-right > widget:last-child > #clock,
       .modules-right > widget:last-child > #custom-powermenu,
       .modules-right > widget:last-child > #custom-notification {
@@ -197,6 +191,10 @@
       #tray {
         background-color: #${config.colorScheme.palette.base00};
         padding: 1px 8px;
+      }
+      #tray:hover {
+        background-color: #${config.colorScheme.palette.base04};
+        color: #${config.colorScheme.palette.base09};
       }
       #tray > .passive {
         -gtk-icon-effect: dim;

--- a/home/zsh/default.nix
+++ b/home/zsh/default.nix
@@ -43,7 +43,7 @@
     autosuggestion.enable  = true;
     enableCompletion = true;
     historySubstringSearch.enable = true;
-    initExtra = ''
+    initContent = ''
       POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD=true
       bindkey '^[OA' history-substring-search-up
       bindkey '^[[A' history-substring-search-up

--- a/hosts/desktop-nix/impermanence.nix
+++ b/hosts/desktop-nix/impermanence.nix
@@ -7,6 +7,12 @@
       "/etc/nixos"
       "/etc/NetworkManager"
       "/var/lib/bluetooth"
+      # State: UEFI NVRAM, dnsmasq leases, snapshots, swtpm state, etc.
+      # (also covers /var/lib/libvirt/images if you use the default pool)
+      "/var/lib/libvirt"
+      # vTPM Local CA (only if you’ve enabled it)
+      "/var/lib/swtpm"
+      "/var/lib/swtpm-localca"
     ];
     files = [
       "/etc/machine-id"

--- a/hosts/fw16-nix/default.nix
+++ b/hosts/fw16-nix/default.nix
@@ -36,6 +36,8 @@ in
     sops.secrets."joplin_sync_region" = { };
     sops.secrets."joplin_sync_username" = { };
     sops.secrets."joplin_sync_api_token" = { };
+    # Tailscale Authkey:
+    sops.secrets."tailscale_auth_key" = { };
     # Wired Network Connection 1:
     sops.secrets."wired_connection_1_ip" = { };
     sops.secrets."wired_connection_1_dns" = { };

--- a/hosts/fw16-nix/default.nix
+++ b/hosts/fw16-nix/default.nix
@@ -90,7 +90,7 @@ in
     home-manager.users.${user}.colorscheme = inputs.nix-colors.colorSchemes.${scheme};
 
     networking = {
-      enableIPv6 = false;
+      enableIPv6 = true;
       hostName = "fw16-nix";
       hostId = "36a96503"; # FIXME required for ZFS. Should be unique.
       firewall.enable = true;

--- a/hosts/fw16-nix/hardware-configuration.nix
+++ b/hosts/fw16-nix/hardware-configuration.nix
@@ -67,7 +67,7 @@
     #"pci-stub.ids=1002:7480,1002:ab30"
     "mem_sleep_default=deep" # Fix for AMD-related power-draw while syspended/sleeping
   ];
-  boot.kernelPackages = pkgs.linuxPackages_6_15; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
+  boot.kernelPackages = pkgs.linuxPackages_6_16; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
   boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];# Used for OBS virtual cameras as Zoom screen sharing workaround
 
   swapDevices = [ ];

--- a/hosts/fw16-nix/hardware-configuration.nix
+++ b/hosts/fw16-nix/hardware-configuration.nix
@@ -67,7 +67,7 @@
     #"pci-stub.ids=1002:7480,1002:ab30"
     "mem_sleep_default=deep" # Fix for AMD-related power-draw while syspended/sleeping
   ];
-  boot.kernelPackages = pkgs.linuxPackages_6_13; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
+  boot.kernelPackages = pkgs.linuxPackages_6_15; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
   boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];# Used for OBS virtual cameras as Zoom screen sharing workaround
 
   swapDevices = [ ];

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -7,10 +7,10 @@
       # Primary external monior (centered)
       monitor=DP-3,3840x2160@30.00,6400x0,1
       # Primary monitor when run through TB3 dock
-      monitor=DP-8,3840x2160@60.00,6400x0,1
+      monitor=DP-7,3840x2160@60.00,6400x0,1
 
       # Secondary monitor (LEFT) when run through TB3 dock
-      monitor=DP-7,3840x2160@60.00,2560x0,1
+      monitor=DP-8,3840x2160@60.00,2560x0,1
 
       # Secondary external monitor. Place it to the right of primary & rotate 90 deg
       #monitor=DP-2,3840x2160@30.00, 2560x0, 1, transform, 1

--- a/hosts/fw16-nix/per-device.nix
+++ b/hosts/fw16-nix/per-device.nix
@@ -7,10 +7,10 @@
       # Primary external monior (centered)
       monitor=DP-3,3840x2160@30.00,6400x0,1
       # Primary monitor when run through TB3 dock
-      monitor=DP-7,3840x2160@60.00,6400x0,1
+      monitor=DP-8,3840x2160@60.00,6400x0,1
 
       # Secondary monitor (LEFT) when run through TB3 dock
-      monitor=DP-8,3840x2160@60.00,2560x0,1
+      monitor=DP-7,3840x2160@60.00,2560x0,1
 
       # Secondary external monitor. Place it to the right of primary & rotate 90 deg
       #monitor=DP-2,3840x2160@30.00, 2560x0, 1, transform, 1

--- a/hosts/ll-nix1/impermanence.nix
+++ b/hosts/ll-nix1/impermanence.nix
@@ -7,6 +7,12 @@
       "/etc/nixos"
       "/etc/NetworkManager"
       "/var/lib/bluetooth"
+      # State: UEFI NVRAM, dnsmasq leases, snapshots, swtpm state, etc.
+      # (also covers /var/lib/libvirt/images if you use the default pool)
+      "/var/lib/libvirt"
+      # vTPM Local CA (only if you’ve enabled it)
+      "/var/lib/swtpm"
+      "/var/lib/swtpm-localca"
     ];
     files = [
       "/etc/machine-id"

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -241,6 +241,7 @@
       NIXOS_OZONE_WL = "1"; # fixes electron apps in Wayland?
       XDG_SESSION_TYPE = "wayland";
       GIO_EXTRA_MODULES= lib.mkForce "${pkgs.gvfs}/lib/gio/modules:${pkgs.dconf.lib}/lib/gio/modules"; # Fix to get file managers (thunar, etc) to be able to mount SMB / CIFS / NFS and trash locations using gvfs
+      TS_AUTH_KEY = "file:/run/secrets/tailscale_auth_key";
     };
     shells = with pkgs; [zsh]; # default shell to zsh
     systemPackages = with pkgs; [

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -241,6 +241,7 @@
     };
     shells = with pkgs; [zsh]; # default shell to zsh
     systemPackages = with pkgs; [
+      #amass
       ansible
       awscli2 # AWS CLI v2
       brightnessctl
@@ -286,6 +287,7 @@
       tailscale
       terraform
       terraform-docs
+      terraform-ls
       tfsec
       tree
       unzip

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -76,6 +76,9 @@
     config = {
       # Disable if you don't want unfree packages
       allowUnfree = true;
+      permittedInsecurePackages = [
+        "libsoup-2.74.3"
+      ];
     };
   };
 

--- a/pkgs/globalprotect/gpauth.nix
+++ b/pkgs/globalprotect/gpauth.nix
@@ -12,17 +12,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gpauth";
-  version = "2.4.4";
+  version = "2.4.5";
 
   src = fetchFromGitHub {
     owner = "yuezk";
     repo = "GlobalProtect-openconnect";
     rev = "v${version}";
-    hash = "sha256-MY4JvftrC6sR8M0dFvnGZOkvHIhPRcyct9AG/8527gw=";
+    hash = "sha256-CqEdLZJs0hvrkB6trCysLnOCj+LuIjqnzGS+HsB7TmQ=";
   };
 
   buildAndTestSubdir = "apps/gpauth";
-  cargoHash = "sha256-8LSGuRnWRWeaY6t25GdZ2y4hGIJ+mP3UBXRjcvPuD6U=";
+  cargoHash = "sha256-vSb5Thv3mEp/gp4/I3WWF/aGfTEKj9+8Mdw6E39YGl4=";
 
   nativeBuildInputs = [
     perl

--- a/pkgs/globalprotect/gpclient.nix
+++ b/pkgs/globalprotect/gpclient.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   inherit (gpauth) version src meta;
 
   buildAndTestSubdir = "apps/gpclient";
-  cargoHash = "sha256-8LSGuRnWRWeaY6t25GdZ2y4hGIJ+mP3UBXRjcvPuD6U=";
+  cargoHash = "sha256-vSb5Thv3mEp/gp4/I3WWF/aGfTEKj9+8Mdw6E39YGl4=";
 
   nativeBuildInputs = [ perl jq webkitgtk_4_1 libsoup_3 pkg-config ];
   PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";


### PR DESCRIPTION
- [replace deprecated programs.zsh.initExtra with programs.zsh.initContent](https://github.com/psiri/nixos-config/commit/df93f1b6e78dbae9997d9bef834d9e88de4efbf3)
- [fix terraform vscode / codium plugin issue](https://github.com/psiri/nixos-config/commit/a9ba85dbce481e051738e24c24a40a65e81506a3)
- [bump globalprotect-openconnect and update waybar](https://github.com/psiri/nixos-config/commit/0ce632faba50609e6d3e1fa2ab8b1877ace2deb1)
- [tailscale automatic login using authkey](https://github.com/psiri/nixos-config/commit/083f03729d0aaa696c8a46c5fc4ff333190e833c)
- [waybar reload keybind](https://github.com/psiri/nixos-config/commit/083f03729d0aaa696c8a46c5fc4ff333190e833c)
- [impermanence update to support persistent kvm vms](https://github.com/psiri/nixos-config/commit/083f03729d0aaa696c8a46c5fc4ff333190e833c)
- [kernel 6.16](https://github.com/psiri/nixos-config/commit/083f03729d0aaa696c8a46c5fc4ff333190e833c)
