### PR TITLE
0.2.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764627417,
-        "narHash": "sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4=",
+        "lastModified": 1766150702,
+        "narHash": "sha256-P0kM+5o+DKnB6raXgFEk3azw8Wqg5FL6wyl9jD+G5a4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5a88a6eceb8fd732b983e72b732f6f4b8269bef3",
+        "rev": "916506443ecd0d0b4a0f4cf9d40a3c22ce39b378",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1764440730,
-        "narHash": "sha256-ZlJTNLUKQRANlLDomuRWLBCH5792x+6XUJ4YdFRjtO4=",
+        "lastModified": 1767185284,
+        "narHash": "sha256-ljDBUDpD1Cg5n3mJI81Hz5qeZAwCGxon4kQW3Ho3+6Q=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9154f4569b6cdfd3c595851a6ba51bfaa472d9f3",
+        "rev": "40b1a28dce561bea34858287fbb23052c3ee63fe",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764952935,
-        "narHash": "sha256-cRPB2zESVMjIGxJ49qj4t4qnT0ae44E+fS/mkfOS/BY=",
+        "lastModified": 1767104570,
+        "narHash": "sha256-GKgwu5//R+cLdKysZjGqvUEEOGXXLdt93sNXeb2M/Lk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "519828bf1c97f8bc2ed2d3b79214067047d3c67d",
+        "rev": "e4e78a2cbeaddd07ab7238971b16468cc1d14daf",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1764440730,
-        "narHash": "sha256-ZlJTNLUKQRANlLDomuRWLBCH5792x+6XUJ4YdFRjtO4=",
+        "lastModified": 1767185284,
+        "narHash": "sha256-ljDBUDpD1Cg5n3mJI81Hz5qeZAwCGxon4kQW3Ho3+6Q=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "9154f4569b6cdfd3c595851a6ba51bfaa472d9f3",
+        "rev": "40b1a28dce561bea34858287fbb23052c3ee63fe",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764667669,
-        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "lastModified": 1767116409,
+        "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "cad22e7d996aea55ecab064e84834289143e44a0",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764667669,
-        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "lastModified": 1767116409,
+        "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "cad22e7d996aea55ecab064e84834289143e44a0",
         "type": "github"
       },
       "original": {
@@ -171,10 +171,10 @@
     "private-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1764975001,
-        "narHash": "sha256-Icw8wtbL16xD9r5GUj5vfGDr5z8nbsU+uOoAZ9fnyno=",
+        "lastModified": 1765288464,
+        "narHash": "sha256-siDGYeYe1Wg97wcJBunVYfAoWRfcRBuY59Q/GGWM8z0=",
         "ref": "main",
-        "rev": "0a71968f91d5b2cd9aa277482c77be667d1cfc32",
+        "rev": "c5e0ad99577bbeaab908221ca339fc5639cef8af",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/psiri/nixos-secrets.git"
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764483358,
-        "narHash": "sha256-EyyvCzXoHrbL467YSsQBTWWg4sR96MH1sPpKoSOelB4=",
+        "lastModified": 1766894905,
+        "narHash": "sha256-pn8AxxfajqyR/Dmr1wnZYdUXHgM3u6z9x0Z1Ijmz2UQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5aca6ff67264321d47856a2ed183729271107c9c",
+        "rev": "61b39c7b657081c2adc91b75dd3ad8a91d6f07a7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764603455,
-        "narHash": "sha256-Q70rxlbrxPcTtqWIb9+71rkJESxIOou5isZBvyOieXw=",
+        "lastModified": 1764952935,
+        "narHash": "sha256-cRPB2zESVMjIGxJ49qj4t4qnT0ae44E+fS/mkfOS/BY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "effe4c007d6243d9e69ce2242d76a2471c1b8d5c",
+        "rev": "519828bf1c97f8bc2ed2d3b79214067047d3c67d",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
         "type": "github"
       },
       "original": {
@@ -171,10 +171,10 @@
     "private-secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1756579167,
-        "narHash": "sha256-9F1fjLv0RakiEtc4AscKMzE7a3dRytaFNX4xXK0EDmk=",
+        "lastModified": 1764975001,
+        "narHash": "sha256-Icw8wtbL16xD9r5GUj5vfGDr5z8nbsU+uOoAZ9fnyno=",
         "ref": "main",
-        "rev": "50d723fd1976e12650a3019d5a9832fe32f821c6",
+        "rev": "0a71968f91d5b2cd9aa277482c77be667d1cfc32",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/psiri/nixos-secrets.git"

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764110879,
-        "narHash": "sha256-xanUzIb0tf3kJ+PoOFmXEXV1jM3PjkDT/TQ5DYeNYRc=",
+        "lastModified": 1764627417,
+        "narHash": "sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "aecba248f9a7d68c5d1ed15de2d1c8a4c994a3c5",
+        "rev": "5a88a6eceb8fd732b983e72b732f6f4b8269bef3",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1764080039,
-        "narHash": "sha256-b1MtLQsQc4Ji1u08f+C6g5XrmLPkJQ1fhNkCt+0AERQ=",
+        "lastModified": 1764440730,
+        "narHash": "sha256-ZlJTNLUKQRANlLDomuRWLBCH5792x+6XUJ4YdFRjtO4=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "da17006633ca9cda369be82893ae36824a2ddf1a",
+        "rev": "9154f4569b6cdfd3c595851a6ba51bfaa472d9f3",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764135300,
-        "narHash": "sha256-5xOuutXM7UPTUcn3uDAD8UlPQsXmqPrX81cXoDOAGcA=",
+        "lastModified": 1764603455,
+        "narHash": "sha256-Q70rxlbrxPcTtqWIb9+71rkJESxIOou5isZBvyOieXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4cb25928fafa9ae68660fe71f730fc820a59028",
+        "rev": "effe4c007d6243d9e69ce2242d76a2471c1b8d5c",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1764080039,
-        "narHash": "sha256-b1MtLQsQc4Ji1u08f+C6g5XrmLPkJQ1fhNkCt+0AERQ=",
+        "lastModified": 1764440730,
+        "narHash": "sha256-ZlJTNLUKQRANlLDomuRWLBCH5792x+6XUJ4YdFRjtO4=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "da17006633ca9cda369be82893ae36824a2ddf1a",
+        "rev": "9154f4569b6cdfd3c595851a6ba51bfaa472d9f3",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763966396,
-        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "lastModified": 1764517877,
+        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1763966396,
-        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "lastModified": 1764517877,
+        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764021963,
-        "narHash": "sha256-1m84V2ROwNEbqeS9t37/mkry23GBhfMt8qb6aHHmjuc=",
+        "lastModified": 1764483358,
+        "narHash": "sha256-EyyvCzXoHrbL467YSsQBTWWg4sR96MH1sPpKoSOelB4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c482a1c1bbe030be6688ed7dc84f7213f304f1ec",
+        "rev": "5aca6ff67264321d47856a2ed183729271107c9c",
         "type": "github"
       },
       "original": {

--- a/home/git/default.nix
+++ b/home/git/default.nix
@@ -8,7 +8,7 @@
     enable = true;
     settings = {
       color.ui = true;
-      #credential.helper = "libsecret";   # OR "store"  # What is the most secure option?
+      credential.helper = "store     ";   # libsecret OR "store"  # What is the most secure option?
       core.askPass = "";                  # "" = use terminal to ask pass
       github.user = "psiri";              # FIXME - Change to your Git username
       init.defaultBranch = "main";

--- a/home/kitty/default.nix
+++ b/home/kitty/default.nix
@@ -75,10 +75,20 @@
       cd ~/.aws
       launch --env KITTY_TAB_HISTORY=${histPath}/ssm-history
 
-      # Tab 5: TFL
+      # Tab 5: TS
+      new_tab TS
+      cd ~
+      launch --env KITTY_TAB_HISTORY=${histPath}/ts-history
+
+      # Tab 6: TFL
       new_tab TFL
       cd ~
       launch --env KITTY_TAB_HISTORY=${histPath}/tfl-history
+
+      # Tab 7: VPN
+      new_tab VPN
+      cd ~
+      launch --env KITTY_TAB_HISTORY=${histPath}/vpn-history
     '';
     home.file.".config/hypr/per-app/kitty.conf" = {
       text = ''

--- a/home/kitty/default.nix
+++ b/home/kitty/default.nix
@@ -35,12 +35,28 @@
         cursor_shape = "beam";
         cursor_beam_thickness = "2.0";
         cursor_blink_interval = "0.5";
+        startup_session = "startup.session";
         strip_trailing_spaces = "always";
-        extraCofig = ''
+        extraConfig = ''
           symbol_map U+E0A0-U+E0A3,U+E0C0-U+E0C7 PowerlineSymbols
         '';
       };
     };
+    xdg.configFile."kitty/startup.session".text = ''
+      # Tab 1: Home
+      cd ~
+      launch 
+
+      # Tab 2: Downloads
+      new_tab Downloads
+      cd ~/Downloads
+      launch
+
+      # Tab 3: Documents
+      new_tab Documents
+      cd ~/Documents
+      launch
+    '';
     home.file.".config/hypr/per-app/kitty.conf" = {
       text = ''
         windowrulev2 = opacity 0.8 0.8, class:^(kitty)$

--- a/home/kitty/default.nix
+++ b/home/kitty/default.nix
@@ -8,6 +8,11 @@
   ...
 }: {
   home-manager.users.${user} = {
+
+    # Ensure the history directory exists
+    xdg.configFile."kitty/history/.keep".text = "";
+
+
     programs.kitty = {
       enable = true;
       settings = {
@@ -40,22 +45,40 @@
         extraConfig = ''
           symbol_map U+E0A0-U+E0A3,U+E0C0-U+E0C7 PowerlineSymbols
         '';
+
+        # INCREASED SCROLLBACK: Keep 100,000 lines in memory (approx 10MB)
+        scrollback_lines = 100000;
       };
     };
-    xdg.configFile."kitty/startup.session".text = ''
+    # --- SESSION CONFIGURATION ---
+    # Set per-tab session history using individual history files.
+    # zsh programs.zsh.initContent script is responsible for automatically switching to the respective hitory file
+    xdg.configFile."kitty/startup.session".text = let
+      histPath = "/home/${user}/.config/kitty/history";
+    in ''
       # Tab 1: Home
       cd ~
-      launch 
+      launch
 
       # Tab 2: Downloads
       new_tab Downloads
       cd ~/Downloads
-      launch
+      launch --env KITTY_TAB_HISTORY=${histPath}/downloads-history
 
       # Tab 3: Documents
       new_tab Documents
       cd ~/Documents
-      launch
+      launch --env KITTY_TAB_HISTORY=${histPath}/documents-history
+
+      # Tab 4: SSM
+      new_tab SSM
+      cd ~/.aws
+      launch --env KITTY_TAB_HISTORY=${histPath}/ssm-history
+
+      # Tab 5: TFL
+      new_tab TFL
+      cd ~
+      launch --env KITTY_TAB_HISTORY=${histPath}/tfl-history
     '';
     home.file.".config/hypr/per-app/kitty.conf" = {
       text = ''

--- a/home/thunar/default.nix
+++ b/home/thunar/default.nix
@@ -9,10 +9,10 @@
 }: {
   programs.thunar = {
     enable = true;
-    plugins = with pkgs.xfce; [
-      thunar-archive-plugin
-      thunar-volman
-    ];
+    # plugins = with pkgs.xfce; [
+    #   thunar-archive-plugin # moved to top-level package "thunar-archive-plugin"
+    #   thunar-volman         # moved to top-level package "thunar-volman"
+    # ];
   };
   services = {
     gvfs = {

--- a/home/zsh/default.nix
+++ b/home/zsh/default.nix
@@ -10,7 +10,7 @@
   # ZSH with powerlevel10k plugin
 
   programs.zsh = {
-    dotDir = config.home.homeDirectory;
+    #dotDir = "${config.xdg.configHome}/zsh";
     enable = true;
     enableBashCompletion = true;
     enableCompletion = true;

--- a/home/zsh/default.nix
+++ b/home/zsh/default.nix
@@ -10,6 +10,7 @@
   # ZSH with powerlevel10k plugin
 
   programs.zsh = {
+    dotDir = config.home.homeDirectory;
     enable = true;
     enableBashCompletion = true;
     enableCompletion = true;

--- a/home/zsh/default.nix
+++ b/home/zsh/default.nix
@@ -49,6 +49,22 @@
       bindkey '^[[A' history-substring-search-up
       bindkey '^[OB' history-substring-search-down
       bindkey '^[[B' history-substring-search-down
+
+      # If Kitty passed a specific history file, switch to it now
+      if [[ -n "$KITTY_TAB_HISTORY" ]]; then
+        # Ensure the custom history file exists
+        if [[ ! -f "$KITTY_TAB_HISTORY" ]]; then
+          touch "$KITTY_TAB_HISTORY"
+        fi
+        
+        # 'fc -p' switches history to the new file and clears the previous (global) history from memory.
+        # Usage: fc -p [file] [histsize] [savehist]
+        fc -p "$KITTY_TAB_HISTORY" 50000 50000
+        
+        # Ensure commands are written immediately, not just on exit
+        setopt INC_APPEND_HISTORY
+        setopt SHARE_HISTORY
+      fi
     '';
     plugins = [
       {

--- a/hosts/fw16-nix/default.nix
+++ b/hosts/fw16-nix/default.nix
@@ -105,15 +105,15 @@ in
     environment = {
       systemPackages = with pkgs; [
         age
-        qmk
-        qmk-udev-rules
+        #qmk # temporarily comment-out due to dfu-programmer dependency issue preventing builds
+        #qmk-udev-rules
         sops
 
         # Framework specific packages
         framework-tool
         linuxKernel.packages.linux_zen.framework-laptop-kmod
       ];
-      shellAliases.rebuild = "sudo rm -rf /tmp/dotfiles && sudo git clone --branch 0.0.5 https://github.com/psiri/nixos-config /tmp/dotfiles && sudo nixos-rebuild switch --flake /tmp/dotfiles/.#fw16-nix --impure";
+      shellAliases.rebuild = "sudo rm -rf /tmp/dotfiles && sudo git clone --branch 0.2.1 https://github.com/psiri/nixos-config /tmp/dotfiles && sudo nixos-rebuild switch --flake /tmp/dotfiles/.#fw16-nix --impure";
     };
 
     services = {

--- a/hosts/fw16-nix/default.nix
+++ b/hosts/fw16-nix/default.nix
@@ -15,6 +15,7 @@ in
       nix-colors.homeManagerModules.default
       ./per-device.nix             # per device hypr configuration
       ./hardware-configuration.nix # device-specific hardware configuration
+      ./vms.nix                    # device-specific VM and Container configs
       ../standard.nix              # standard or server config template
       ./network-manager.nix        # device-specific configurations for networkmanager with rendered secrets
       #../../home/barrier          # Does not support Wayland

--- a/hosts/fw16-nix/hardware-configuration.nix
+++ b/hosts/fw16-nix/hardware-configuration.nix
@@ -67,8 +67,9 @@
     #"pci-stub.ids=1002:7480,1002:ab30"
     "mem_sleep_default=deep" # Fix for AMD-related power-draw while syspended/sleeping
   ];
-  boot.kernelPackages = pkgs.linuxPackages_6_17; #config.boot.zfs.package.latestCompatibleLinuxPackages; 
+  boot.kernelPackages = pkgs.linuxPackages_6_18;
   boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];# Used for OBS virtual cameras as Zoom screen sharing workaround
+  boot.zfs.package = pkgs.zfs_2_4; # Explicitly specify kernel 6.18-compatible ZFS package
 
   swapDevices = [ ];
 

--- a/hosts/fw16-nix/hardware-configuration.nix
+++ b/hosts/fw16-nix/hardware-configuration.nix
@@ -67,7 +67,7 @@
     #"pci-stub.ids=1002:7480,1002:ab30"
     "mem_sleep_default=deep" # Fix for AMD-related power-draw while syspended/sleeping
   ];
-  boot.kernelPackages = pkgs.linuxPackages_6_18;
+  boot.kernelPackages = pkgs.linuxPackages_6_18; # Linux kernel 6.18
   boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];# Used for OBS virtual cameras as Zoom screen sharing workaround
   boot.zfs.package = pkgs.zfs_2_4; # Explicitly specify kernel 6.18-compatible ZFS package
 
@@ -101,14 +101,10 @@
       enable32Bit = true;
       enable = true;
       extraPackages = with pkgs; [
-        #amdvlk # Deprecated and replaced by RADV, which is enabled by default
         libva
         libvdpau
         libvdpau-va-gl
         libva-vdpau-driver
-      ];
-      extraPackages32 = [
-        #pkgs.driversi686Linux.amdvlk # Deprecated and replaced by RADV, which is enabled by default
       ];
     };
     # steam-hardware.enable = true;

--- a/hosts/fw16-nix/vms.nix
+++ b/hosts/fw16-nix/vms.nix
@@ -21,8 +21,8 @@ let
           <feature enabled="no" name="enrolled-keys"/>
           <feature enabled="yes" name="secure-boot"/>
         </firmware>
-        <loader readonly="yes" secure="yes" type="pflash" format="raw">${ovmfPackage.fd}/FV/OVMF_CODE.fd</loader>
-        <nvram template="${ovmfPackage.fd}/FV/OVMF_VARS.fd" templateFormat="raw" format="raw">/var/lib/libvirt/qemu/nvram/win11_VARS.fd</nvram>
+        <loader readonly="yes" secure="yes" type="pflash" format="raw">${pkgs.OVMFFull.fd}/FV/OVMF_CODE.fd</loader>
+        <nvram template="${pkgs.OVMFFull.fd}/FV/OVMF_VARS.fd" templateFormat="raw" format="raw">/var/lib/libvirt/qemu/nvram/win11_VARS.fd</nvram>
         <boot dev="hd"/>
       </os>
       <features>

--- a/hosts/fw16-nix/vms.nix
+++ b/hosts/fw16-nix/vms.nix
@@ -1,0 +1,104 @@
+{ config, pkgs, ... }:
+
+let
+  # Define VM XML file with nix interpolations for store paths
+  #   then use pkgs.writeText to create the XML file in the Nix store.
+  vmXml = pkgs.writeText "win11.xml" ''
+    <domain type="kvm">
+      <name>win11</name>
+      <uuid>2cf84820-7e46-4e59-9ec0-ab6515aace54</uuid>
+      <metadata>
+        <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+          <libosinfo:os id="http://microsoft.com/win/11"/>
+        </libosinfo:libosinfo>
+      </metadata>
+      <memory unit="KiB">16777216</memory>
+      <currentMemory unit="KiB">16777216</currentMemory>
+      <vcpu placement="static">4</vcpu>
+      <os firmware="efi">
+        <type arch="x86_64" machine="pc-q35-9.2">hvm</type>
+        <firmware>
+          <feature enabled="no" name="enrolled-keys"/>
+          <feature enabled="yes" name="secure-boot"/>
+        </firmware>
+        <loader readonly="yes" secure="yes" type="pflash" format="raw">${ovmfPackage.fd}/FV/OVMF_CODE.fd</loader>
+        <nvram template="${ovmfPackage.fd}/FV/OVMF_VARS.fd" templateFormat="raw" format="raw">/var/lib/libvirt/qemu/nvram/win11_VARS.fd</nvram>
+        <boot dev="hd"/>
+      </os>
+      <features>
+        <acpi/>
+        <apic/>
+        <hyperv mode="custom">
+          <relaxed state="on"/>
+          <vapic state="on"/>
+          <spinlocks state="on" retries="8191"/>
+          <vpindex state="on"/>
+          <runtime state="on"/>
+          <synic state="on"/>
+          <stimer state="on"/>
+          <frequencies state="on"/>
+          <tlbflush state="on"/>
+          <ipi state="on"/>
+          <avic state="on"/>
+        </hyperv>
+        <vmport state="off"/>
+        <smm state="on"/>
+      </features>
+      <cpu mode="host-passthrough" check="none" migratable="on"/>
+      <clock offset="localtime">
+        <timer name="rtc" tickpolicy="catchup"/>
+        <timer name="pit" tickpolicy="delay"/>
+        <timer name="hpet" present="no"/>
+        <timer name="hypervclock" present="yes"/>
+      </clock>
+      <on_poweroff>destroy</on_poweroff>
+      <on_reboot>restart</on_reboot>
+      <on_crash>destroy</on_crash>
+      <pm>
+        <suspend-to-mem enabled="no"/>
+        <suspend-to-disk enabled="no"/>
+      </pm>
+      <devices>
+        <emulator>${pkgs.qemu_kvm}/bin/qemu-system-x86_64</emulator>
+        <disk type="file" device="disk">
+          <driver name="qemu" type="qcow2"/>
+          <source file="/home/psiri/Documents/vms/vm-win11.qcow2"/>
+          <target dev="vda" bus="virtio"/>
+          <address type="pci" domain="0x0000" bus="0x04" slot="0x00" function="0x0"/>
+        </disk>
+        <interface type="network">
+          <mac address="52:54:00:b2:ff:a5"/>
+          <source network="wired"/> <model type="virtio"/>
+          <address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>
+        </interface>
+        
+        <graphics type="spice">
+          <listen type="none"/>
+          <image compression="off"/>
+          <gl enable="yes" rendernode="/dev/dri/by-path/pci-0000:c1:00.0-render"/>
+        </graphics>
+        <video>
+          <model type="virtio" heads="1" primary="yes">
+            <acceleration accel3d="yes"/>
+          </model>
+          <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0"/>
+        </video>
+      </devices>
+    </domain>
+  '';
+in
+{
+
+  # Run 'virsh define' on every activation, keeping the XML in sync with the current Nix store paths.
+  systemd.services.define-vms = {
+    description = "Define libvirt domains from Nix store";
+    after = [ "libvirtd.service" ];
+    requires = [ "libvirtd.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      # Define the VM. If it exists, it updates the config.
+      ExecStart = "${pkgs.libvirt}/bin/virsh define ${vmXml}";
+    };
+  };
+}

--- a/hosts/standard.nix
+++ b/hosts/standard.nix
@@ -305,6 +305,8 @@
       terraform-docs
       terraform-ls
       tfsec
+      thunar-archive-plugin
+      thunar-volman
       tree
       unzip
       usbutils # usb thing

--- a/modules/virt/default.nix
+++ b/modules/virt/default.nix
@@ -16,7 +16,7 @@
         swtpm.enable = true;
         swtpm.package = pkgs.swtpm;
         #ovmf.enable = true; # No longer required, bundled with QEMU
-        ovmf.packages = [ pkgs.OVMFFull.fd ];
+        #ovmf.packages = [ pkgs.OVMFFull.fd ];
       };
     };
     spiceUSBRedirection.enable = true;

--- a/modules/virt/default.nix
+++ b/modules/virt/default.nix
@@ -16,7 +16,7 @@
         swtpm.enable = true;
         swtpm.package = pkgs.swtpm;
         #ovmf.enable = true; # No longer required, bundled with QEMU
-        #ovmf.packages = [ pkgs.OVMFFull.fd ];
+        ovmf.packages = [ pkgs.OVMFFull.fd ];
       };
     };
     spiceUSBRedirection.enable = true;


### PR DESCRIPTION
- Add declarative KVM VM definitions
- Add kitty default-startup tabs for various functionality, each with separate history
- Update thunar plugins to use top-level packages
- temporarily remove qmk due to [https://github.com/NixOS/nixpkgs/issues/472891](https://github.com/NixOS/nixpkgs/issues/472891)
- bump kernel to 6.18
- update zfs to 2.4.0